### PR TITLE
Add missing ',' to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   "soulsam480/nvim-oxlint",
   opts = {
     run = 'onSave',
-    config_path = '.oxlintrc.json'
+    config_path = '.oxlintrc.json',
     enable = true,
     type_aware = true
   }


### PR DESCRIPTION
Hi!

Thank you for making this plugin.

I ran into this issue when adding nvim-oxlint to my config.